### PR TITLE
API supports saving

### DIFF
--- a/api/src/integrationTest/groovy/ncei/catalog/SaveDataAPISpec.groovy
+++ b/api/src/integrationTest/groovy/ncei/catalog/SaveDataAPISpec.groovy
@@ -1,0 +1,92 @@
+package ncei.catalog
+
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.hamcrest.Matchers.hasItems
+import static org.hamcrest.Matchers.equalTo
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+
+@SpringBootTest(classes = [ApiApplication], webEnvironment = RANDOM_PORT)
+class SaveDataAPISpec extends Specification {
+
+  @Value('${local.server.port}')
+  private String port
+
+  @Value('${server.context-path:/}')
+  private String contextPath
+
+  @Shared
+  private String appUrl
+
+//  def poller = new PollingConditions(timeout: 5)
+
+  def setup() {
+    RestAssured.baseURI = "http://localhost"
+    RestAssured.port = port as Integer
+    RestAssured.basePath = contextPath
+    appUrl = "${RestAssured.baseURI}:${RestAssured.port}/api"
+  }
+
+  @Unroll
+  def 'save new granules with #trackingId and #filename'() {
+    when: 'posting a new granule to the storage'
+    String id = RestAssured.given()
+        .body([
+          "tracking_id": trackingId,
+          "filename": filename
+        ])
+        .contentType(ContentType.JSON)
+        .when()
+        .post("${appUrl}/${route}/${path}")
+        .then()
+        .assertThat()
+        .statusCode(201)
+        .extract()
+        .path('data[0].id')
+
+    then: 'id returned is not null'
+    id != null
+
+    and: 'eventually searching the index finds the record'
+    /*
+    poller.eventually {
+
+      sleep(500)
+
+      def result = RestAssured.given()
+          .contentType(ContentType.JSON)
+          .params([q: "_id:$id"])
+          .when()
+          .get("${appUrl}/index/index/search")
+          .then()
+          .extract()
+//      assert result.response().statusCode == 200
+      assert result.body().path("data.id").contains(id)
+    }
+    // */
+
+    sleep(1000)
+    RestAssured.given()
+        .contentType(ContentType.JSON)
+        .params([q: "_id:$id"])
+        .when()
+        .get("${appUrl}/index/index/search")
+        .then()
+        .assertThat()
+        .statusCode(200)
+        .body("data.size", equalTo(1))
+        .body("data.id", hasItems(id))
+
+    where:
+    route | path | trackingId | filename
+    'storage1' | 'metadata-catalog/granules' | "abc123" | "some_granule.txt"
+    'storage1' | 'metadata-catalog/granules' | "xyz789" | "a_granule.zip"
+  }
+
+}

--- a/index/README.md
+++ b/index/README.md
@@ -23,7 +23,7 @@ Note: if you are running integration tests and make a change to the docker templ
 ##Saving via RABBITMQ
 Save metadata:
 Properties: content_type = application/json
-Payload: {"GRANULE_ID":"1asdf123s", "dataset":"csb", "fileName":"/blah/fileName1"}
+Payload: {"id":"1asdf123s", "type":"metadata", "attributes": {"dataset":"csb", "fileName":"/blah/fileName1"}}
 
 ##Searching via REST
 http://localhost:8088/index/search?q=dataset:csb fileName:/blah/fileName1

--- a/index/src/integrationTest/groovy/ncei/catalog/controller/IndexControllerApiSpec.groovy
+++ b/index/src/integrationTest/groovy/ncei/catalog/controller/IndexControllerApiSpec.groovy
@@ -59,8 +59,8 @@ class IndexControllerApiSpec extends Specification {
     ]
 
     when: "Inserted data has appeared in elasticsearch"
-    service.insert(metadata)
-    service.insert(metadata2)
+    service.upsert(metadata)
+    service.upsert(metadata2)
     poller.eventually {
       assert service.search().data.size() == 2
     }
@@ -89,8 +89,8 @@ class IndexControllerApiSpec extends Specification {
         type      : "junk",
         attributes: [dataset: "testDataset", fileName: "testFileName2"]
     ]
-    service.insert(metadata)
-    service.insert(metadata2)
+    service.upsert(metadata)
+    service.upsert(metadata2)
 
     when: "Inserted data has appeared in the database"
     def metadataSearch = generateQueryString(metadata.attributes)

--- a/index/src/main/groovy/ncei/catalog/service/MessageService.groovy
+++ b/index/src/main/groovy/ncei/catalog/service/MessageService.groovy
@@ -19,12 +19,18 @@ class MessageService {
     log.info "Received rabbit message: $message"
 
     if (message) {
-      Map response = service.insert(message)
-      if (response.containsKey('data')) {
-        log.info "Insert succeeded: metadata='$message' with Elasticsearch response: $response"
-      } else {
-        log.info "Insert failed: metadata='$message' with Elasticsearch response: $response"
+      try {
+        Map response = service.insert(message)
+
+        if (response?.containsKey('data')) {
+          log.info "Insert succeeded: metadata='$message' with Elasticsearch response: $response"
+        } else {
+          log.info "Insert failed: metadata='$message' with Elasticsearch response: $response"
+        }
+      } catch(e) {
+        log.error("Insert failed:  metadata=$message Exception:", e)
       }
+
     } else {
       log.warn("Insert task - received bad message: '$message'")
     }

--- a/index/src/main/groovy/ncei/catalog/service/MessageService.groovy
+++ b/index/src/main/groovy/ncei/catalog/service/MessageService.groovy
@@ -8,31 +8,90 @@ import org.springframework.stereotype.Component
 @Component
 class MessageService {
 
-  @Autowired
   private Service service
+
+  @Autowired
+  MessageService(Service service) {
+    this.service = service
+  }
 
   /**
    * Via Spring magic this handleMessage is recognized by the spring rabbit plugin.
    * @param message
    */
   void handleMessage(Map message) {
-    log.info "Received rabbit message: $message"
+    try {
+      log.debug "Received rabbit message: $message"
+      processResources(message)
+    }
+    catch(e) {
+      log.error("Processing payload failed:  metadata=$message Exception:", e)
+    }
+  }
 
-    if (message) {
+  /**
+   * Handle a JSON-API style payload with an array of
+   * resources needing to be either upserted or deleted
+   * @param payload The payload to process. Must contain a "data"
+   *                key which is an array of resources to process.
+   * @return A JSON-API style response indicating the results
+   */
+  Map processResources(Map payload) {
+    def resources = payload?.data
+    if (resources instanceof Map) {
+      resources = [resources]
+    }
+    if (!(resources instanceof List)) {
+      log.warn("Received malformed payload of resources to process. Must contain data: ${payload}")
+      return null
+    }
+
+    def created = 0
+    def updated = 0
+    def deleted = 0
+    def failed = 0
+
+    resources.each { resource ->
+      log.debug("Begin update for metadata ${resource}")
+      def result = null
+      def action = resource?.meta?.action
       try {
-        Map response = service.insert(message)
+        switch (action) {
+          case 'insert':
+          case 'update':
+          case 'upsert':
+            log.debug("Upserting metadata with id ${resource?.id}")
+            result = service.upsert(resource)
+            break
 
-        if (response?.containsKey('data')) {
-          log.info "Insert succeeded: metadata='$message' with Elasticsearch response: $response"
-        } else {
-          log.info "Insert failed: metadata='$message' with Elasticsearch response: $response"
+          case 'delete':
+            log.debug("Deleting metadata with id ${resource?.id}")
+            result = service.delete(resource)
+            break
+
+          default:
+            log.warn("Received resource with unexpected action: $action")
         }
-      } catch(e) {
-        log.error("Insert failed:  metadata=$message Exception:", e)
+      }
+      catch (e) {
+        log.warn("An error occurred performing action [$action] on metadata with id ${resource?.id}", e)
       }
 
-    } else {
-      log.warn("Insert task - received bad message: '$message'")
+      if (result?.meta?.created == true) {
+        created++
+      }
+      else if (result?.meta?.created == false) {
+        updated++
+      }
+      else if (result?.meta?.deleted == true) {
+        deleted++
+      }
+      else {
+        failed++
+      }
     }
+
+    log.info("Handled update payload - created: $created, updated: $updated, deleted: $deleted, failed: $failed")
+    return [meta: [created: created, updated: updated, deleted: deleted, failed: failed]]
   }
 }

--- a/index/src/main/groovy/ncei/catalog/service/Service.groovy
+++ b/index/src/main/groovy/ncei/catalog/service/Service.groovy
@@ -7,6 +7,7 @@ import org.apache.http.HttpEntity
 import org.apache.http.entity.ContentType
 import org.apache.http.nio.entity.NStringEntity
 import org.elasticsearch.client.Response
+import org.elasticsearch.client.ResponseException
 import org.elasticsearch.client.RestClient
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -55,22 +56,22 @@ class Service {
   }
 
   /**
-   * Insert the metadata to Elasticsearch
-   * @param metadata data to insert
-   * @return The inserted item
+   * Insert a resource to Elasticsearch
+   * @param resource data to upsert
+   * @return The inserted resource
    */
-  Map insert(Map metadata) {
-    def id = metadata?.id
-    def type = metadata?.type
-    def attributes = metadata?.attributes
+  Map upsert(Map resource) {
+    def id = resource?.id
+    def type = resource?.type
+    def attributes = resource?.attributes
     if (!(id instanceof String || id instanceof Number) || !(type instanceof String) || !(attributes instanceof Map)) {
-      log.warn("Indexed objects must have an id, type, and attributes. Ignoring: ${metadata}")
+      log.warn("Indexed objects must have an id, type, and attributes. Ignoring: ${resource}")
       return null
     }
 
     String endpoint = "/$INDEX/$type/$id"
-    log.debug("Insert: endpoint=$endpoint metadata=$metadata")
-    String metadataStr = JsonOutput.toJson(metadata.attributes)
+    log.debug("Insert: endpoint=$endpoint resource=$resource")
+    String metadataStr = JsonOutput.toJson(resource.attributes)
     HttpEntity entity = new NStringEntity(metadataStr, ContentType.APPLICATION_JSON)
     log.debug("Insert entity=${entity.toString()}")
     Response response = restClient.performRequest(
@@ -82,13 +83,49 @@ class Service {
 
     def result = parseResponse(response)
     return [
-        data: [
-            id        : result._id,
-            type      : result._type,
-            attributes: attributes,
-            meta      : [created: result.created]
-        ]
+        id        : result._id,
+        type      : result._type,
+        attributes: attributes,
+        meta      : [created: result.created]
     ]
+  }
+
+  /**
+   * Delete a resource from Elasticsearch
+   * @param resource data to delete
+   * @return The deleted resource with id, type, and whether it was deleted or not
+   */
+  Map delete(Map resource) {
+    def id = resource?.id
+    def type = resource?.type
+    if (!(id instanceof String || id instanceof Number) || !(type instanceof String)) {
+      log.warn("Can only delete resources with an id and type. Ignoring: ${resource}")
+      return null
+    }
+
+    def result = [id: id, type: type, meta: [deleted: true]]
+    try {
+      String endpoint = "/$INDEX/$type/$id"
+      log.debug("Delete: endpoint=$endpoint resource=$resource")
+      String metadataStr = JsonOutput.toJson(resource.attributes)
+      HttpEntity entity = new NStringEntity(metadataStr, ContentType.APPLICATION_JSON)
+      log.debug("Delete entity=${entity.toString()}")
+      Response response = restClient.performRequest('DELETE', endpoint)
+      log.debug("Delete response: $response")
+
+      def parsed = parseResponse(response)
+      result.meta.deleted = (parsed.result == 'deleted')
+    }
+    catch (ResponseException e) {
+      if (e.getResponse().statusLine.statusCode == 404) {
+        result.meta.deleted = false
+      }
+      else {
+        throw e
+      }
+    }
+
+    return result
   }
 
   private static Map parseResponse(Response response) {

--- a/index/src/test/groovy/ncei/catalog/service/MessageServiceSpec.groovy
+++ b/index/src/test/groovy/ncei/catalog/service/MessageServiceSpec.groovy
@@ -1,47 +1,117 @@
 package ncei.catalog.service
 
-import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
+@Unroll
 class MessageServiceSpec extends Specification {
 
-  MessageService messageService = new MessageService()
-  Service service = Mock(Service)
+  Service mockService = Mock(Service)
+  MessageService messageService = new MessageService(mockService)
 
-  @Shared
-  Map insertMessage = [
-      id        : '1',
-      type      : "junk",
-      attributes: [dataset: "testDataset", fileName: "testFileName1"]
-  ]
-
-  @Shared
-  Map insertReturn = [
-      data: [
-          id        : insertMessage.id,
-          type      : insertMessage.type,
-          attributes: insertMessage.attributes,
-          meta      : [created: true]
-      ]
-  ]
-
-  def setup() {
-    messageService.service = service
-  }
-
-  def 'Rabbit message where insert return is #insertReturnType is gracefully dealt with'() {
-
+  def 'handleMessage gracefully handles a message with #inserts inserts and #deleted deletes'() {
     when:
-    messageService.handleMessage(insertMessage)
+    messageService.handleMessage(buildPayload(inserts, deletes))
 
     then:
-    1 * service.insert(insertMessage) >> mockedInsertReturn
+    inserts * mockService.upsert(_ as Map) >> [meta: [created: true]]
+    deletes * mockService.delete(_ as Map) >> [meta: [deleted: true]]
+
+    and:
     noExceptionThrown()
 
     where:
-    insertReturnType | mockedInsertReturn
-    'a valid result' | insertReturn
-    'null'           | null
-    'an exception'   | {throw new IOException()}
+    inserts | deletes
+    0       | 0
+    1       | 0
+    0       | 1
+    1       | 1
+  }
+
+  def 'handleMessage gracefully handles upsert/delete failures'() {
+    when:
+    messageService.handleMessage(buildPayload(1, 1))
+
+    then: 'upsert and delete fail'
+    1 * mockService.upsert(_ as Map) >> failure
+    1 * mockService.delete(_ as Map) >> failure
+
+    and: 'we never throw an exception and get into an infinite rabbit loop'
+    noExceptionThrown()
+
+    where: 'different ways of failing'
+    failure << [
+        null,
+        { throw new IOException() }
+    ]
+  }
+
+  def 'processResources handles a payload with #inserts inserts and #deleted deletes'() {
+    when:
+    def result = messageService.processResources(buildPayload(inserts, deletes))
+
+    then:
+    inserts * mockService.upsert(_ as Map) >> [meta: [created: true]]
+    deletes * mockService.delete(_ as Map) >> [meta: [deleted: true]]
+
+    and:
+    noExceptionThrown()
+    result == [meta: [created: inserts, updated: 0, deleted: deletes, failed: 0]]
+
+    where:
+    inserts | deletes
+    0       | 0
+    1       | 0
+    0       | 1
+    1       | 1
+    2       | 0
+    0       | 2
+    2       | 2
+  }
+
+  def 'processResources detects updates vs inserts'() {
+    when:
+    def result = messageService.processResources(buildPayload(2, 0))
+
+    then: 'one insert inserts and one updates'
+    1 * mockService.upsert(_ as Map) >> [meta: [created: true]]
+    1 * mockService.upsert(_ as Map) >> [meta: [created: false]]
+
+    and:
+    noExceptionThrown()
+    result == [meta: [created: 1, updated: 1, deleted: 0, failed: 0]]
+  }
+
+  def 'processResources handles upsert/delete failures'() {
+    when:
+    def result = messageService.processResources(buildPayload(2, 2))
+
+    then: 'upsert and delete both called twice and each fail once'
+    1 * mockService.upsert(_ as Map) >> [meta: [created: true]]
+    1 * mockService.upsert(_ as Map) >> failure
+    1 * mockService.delete(_ as Map) >> [meta: [deleted: true]]
+    1 * mockService.delete(_ as Map) >> failure
+
+    and: 'successes and failures are recorded'
+    noExceptionThrown()
+    result == [meta: [created: 1, updated: 0, deleted: 1, failed: 2]]
+
+    where: 'different ways of failing'
+    failure << [
+        null,
+        [whatIsThis: 'a incorrectly structured map!'],
+        { throw new RuntimeException() }
+    ]
+  }
+
+  private static buildPayload(int inserts, int deletes) {
+    def data = []
+    inserts.times { i ->
+      data << [id: "$i", type: 'granule', attributes: [name: "$i"], meta: [action: 'insert']]
+    }
+    deletes.times { i ->
+      data << [id: "$i", type: 'granule', attributes: [name: "$i"], meta: [action: 'delete']]
+    }
+    return [data: data]
   }
 }

--- a/index/src/test/groovy/ncei/catalog/service/MessageServiceSpec.groovy
+++ b/index/src/test/groovy/ncei/catalog/service/MessageServiceSpec.groovy
@@ -1,0 +1,47 @@
+package ncei.catalog.service
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MessageServiceSpec extends Specification {
+
+  MessageService messageService = new MessageService()
+  Service service = Mock(Service)
+
+  @Shared
+  Map insertMessage = [
+      id        : '1',
+      type      : "junk",
+      attributes: [dataset: "testDataset", fileName: "testFileName1"]
+  ]
+
+  @Shared
+  Map insertReturn = [
+      data: [
+          id        : insertMessage.id,
+          type      : insertMessage.type,
+          attributes: insertMessage.attributes,
+          meta      : [created: true]
+      ]
+  ]
+
+  def setup() {
+    messageService.service = service
+  }
+
+  def 'Rabbit message where insert return is #insertReturnType is gracefully dealt with'() {
+
+    when:
+    messageService.handleMessage(insertMessage)
+
+    then:
+    1 * service.insert(insertMessage) >> mockedInsertReturn
+    noExceptionThrown()
+
+    where:
+    insertReturnType | mockedInsertReturn
+    'a valid result' | insertReturn
+    'null'           | null
+    'an exception'   | {throw new IOException()}
+  }
+}

--- a/storage/src/main/groovy/ncei/catalog/controller/CollectionController.groovy
+++ b/storage/src/main/groovy/ncei/catalog/controller/CollectionController.groovy
@@ -66,4 +66,11 @@ class CollectionController {
     repoService.purge(response, collectionMetadataRepository, params)
   }
 
+  @RequestMapping(value = '/recover', method = RequestMethod.PUT)
+  @ResponseBody
+  Map recover(HttpServletResponse response) {
+    log.info 'Attempting to recover all collection metadata records'
+    repoService.recover(response, collectionMetadataRepository)
+  }
+
 }

--- a/storage/src/main/groovy/ncei/catalog/controller/GranuleController.groovy
+++ b/storage/src/main/groovy/ncei/catalog/controller/GranuleController.groovy
@@ -66,4 +66,11 @@ class GranuleController {
     repoService.purge(response, granuleMetadataRepository, params)
   }
 
+  @RequestMapping(value = '/recover', method = RequestMethod.PUT)
+  @ResponseBody
+  Map recover(HttpServletResponse response) {
+    log.info 'Attempting to recover all granule metadata records'
+    repoService.recover(response, granuleMetadataRepository)
+  }
+
 }

--- a/storage/src/main/groovy/ncei/catalog/controller/SchemaController.groovy
+++ b/storage/src/main/groovy/ncei/catalog/controller/SchemaController.groovy
@@ -66,4 +66,10 @@ class SchemaController {
     repoService.purge(response, schemaRepository, params)
   }
 
+  @RequestMapping(value = '/recover', method = RequestMethod.PUT)
+  @ResponseBody
+  Map recover(HttpServletResponse response) {
+    log.info 'Attempting to recover all metadata schemas'
+    repoService.recover(response, schemaRepository)
+  }
 }

--- a/storage/src/main/groovy/ncei/catalog/domain/CollectionMetadataRepository.groovy
+++ b/storage/src/main/groovy/ncei/catalog/domain/CollectionMetadataRepository.groovy
@@ -20,9 +20,6 @@ interface CollectionMetadataRepository extends CassandraRepository<CollectionMet
   @Query("SELECT*FROM CollectionMetadata WHERE granule_schema=?0")
   Iterable<CollectionMetadata> findBySchema(String schema)
 
-  @Query("SELECT*FROM CollectionMetadata WHERE collection_name =?0 AND granule_schema=?1")
-  Iterable<CollectionMetadata> findByCollectionNameAndSchema(String collection_name, String schema)
-
   @Query("SELECT DISTINCT id FROM CollectionMetadata WHERE collection_name=?0")
   Iterable<CollectionMetadata> findDistinctTrackingIdsByCollectionName(String collection_name)
 

--- a/storage/src/main/resources/application.yml
+++ b/storage/src/main/resources/application.yml
@@ -17,4 +17,4 @@ rabbitmq:
     password: guest
 
 spring.mvc.throw-exception-if-no-handler-found: true
-#spring.resources.add-mapping: false
+spring.resources.add-mappings: false


### PR DESCRIPTION
This is a pretty simple test that posts new granules to storage and then checks that they've been indexed, since the API currently just routes to the other two services.

Passing tests pending getting index and storage rabbit messages in sync.

I'm concerned that the poller did not seem to work without including a sleep(500), which defeats the point since a short sleep also makes it work without doing polling at all. I wasn't able to figure out why, so I left that in the comments in case someone else spots something I missed.